### PR TITLE
Remove gradient register

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ tf_slim_description = (
 
 setup(
     name='tf_slim',
-    version='1.0',
+    version='1.1',
     include_package_data=True,
     packages=find_packages(exclude=['docs']),  # Required
     install_requires=install_requires,

--- a/tf_slim/layers/layers.py
+++ b/tf_slim/layers/layers.py
@@ -2145,9 +2145,6 @@ class GDN(base.Layer):
     return input_shape
 
 
-ops.RegisterGradient('GDNLowerBound')(GDN._lower_bound_grad)  # pylint:disable=protected-access
-
-
 def gdn(inputs,
         inverse=False,
         beta_min=1e-6,


### PR DESCRIPTION
Currently tf slim causes the following error:
Exception: "Registering two gradient with name 'GDNLowerBound'! (Previous registration was in register /path/python3.6_tf1.15/lib/python3.6/site-packages/tensorflow_core/python/framework/registry.py:66)"
